### PR TITLE
Url encode query parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ hyper = {version = "0.9.6", default-features = false}
 serde = "0.7.6"
 serde_json = "0.7.1"
 serde_macros = "0.7.5"
+url = "1.1.1"
 
 [dev-dependencies]
 dotenv = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate hyper;
 extern crate serde_json;
 extern crate serde;
+extern crate url;
 
 mod model;
 mod service;

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -163,6 +163,6 @@ fn apply_query<T: Into<String>>(uri: T, query: &Query) -> String {
         uri.push('&');
     }
 
-    query.append_to_buffer(&mut uri);
+    uri.push_str(&query.to_string());
     uri
 }


### PR DESCRIPTION
Before appending params to the query string, apply % encoding to escape invalid characters. This unfortunately represents a regression in that we no longer support appending a query directly to an existing buffer.

Closes #1 
