### PR TITLE
Update for Serde v1.0

### DIFF
--- a/src/model/author.rs
+++ b/src/model/author.rs
@@ -1,5 +1,40 @@
-use model::{AuthorResponse, Content};
+use model::{ApiError, Content, PageRange};
+use serde::{Deserialize, Deserializer};
 use service::{Error, Result};
+use std::result;
+
+#[derive(Debug, Deserialize)]
+pub struct AuthorResponse {
+    // For whatever stupid-ass reason, the *author* api sends back a *string* for the count, not 
+    // a [bleep] number.
+    pub success: Option<AuthorSuccess>,
+    pub error: Option<ApiError>,
+    pub reason: Option<String>,
+    pub contents: Option<AuthorPayload>,
+}
+
+#[derive(Debug)]
+pub struct AuthorSuccess {
+    // This may or may not be a number. /sigh
+    pub total: Option<i32>,
+    pub range: Option<PageRange>,
+}
+
+impl<'d> Deserialize<'d> for AuthorSuccess {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> result::Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Template {
+            total: String,
+            range: Option<PageRange>,
+        }
+
+        let template = Template::deserialize(d)?;
+        Ok(AuthorSuccess {
+            total: template.total.parse().ok(),
+            range: template.range,
+        })
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct AuthorPayload {
@@ -16,19 +51,18 @@ impl Content<Authors> for AuthorResponse {
 
 #[cfg(test)]
 mod tests {
-    use model::ApiResponse;
-    use model::author::AuthorPayload;
+    use model::AuthorResponse;
     use serde_json as json;
 
     #[test]
     fn deserialize_success() {
         let response = include_str!("../../sample_json/authors_response.json");
-        json::from_str::<ApiResponse<AuthorPayload>>(response).expect("unable to deserialize");
+        json::from_str::<AuthorResponse>(response).expect("unable to deserialize");
     }
 
     #[test]
     fn deserialize_failure() {
         let response = include_str!("../../sample_json/authors_bad_response.json");
-        json::from_str::<ApiResponse<AuthorPayload>>(response).expect("unable to deserialize");
+        json::from_str::<AuthorResponse>(response).expect("unable to deserialize");
     }
 }

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -1,5 +1,40 @@
-use model::{Content, CategoryResponse};
+use model::{ApiError, Content, PageRange};
+use serde::{Deserialize, Deserializer};
 use service::{Error, Result};
+use std::result;
+
+#[derive(Debug, Deserialize)]
+pub struct CategoryResponse {
+    // For whatever stupid-ass reason, the *author* api sends back a *string* for the count, not 
+    // a [bleep] number.
+    pub success: Option<CategorySuccess>,
+    pub error: Option<ApiError>,
+    pub reason: Option<String>,
+    pub contents: Option<CategoryPayload>,
+}
+
+#[derive(Debug)]
+pub struct CategorySuccess {
+    // This may or may not be a number. /sigh
+    pub total: Option<i32>,
+    pub range: Option<PageRange>,
+}
+
+impl<'d> Deserialize<'d> for CategorySuccess {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> result::Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Template {
+            total: String,
+            range: Option<PageRange>,
+        }
+
+        let template = Template::deserialize(d)?;
+        Ok(CategorySuccess {
+            total: template.total.parse().ok(),
+            range: template.range,
+        })
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct CategoryPayload {
@@ -16,19 +51,18 @@ impl Content<Categories> for CategoryResponse {
 
 #[cfg(test)]
 mod tests {
-    use model::ApiResponse;
-    use model::category::CategoryPayload;
+    use model::CategoryResponse;
     use serde_json as json;
 
     #[test]
     fn deserialize_categories() {
         let response = include_str!("../../sample_json/category.json");
-        json::from_str::<ApiResponse<CategoryPayload>>(response).expect("unable to deserialize");
+        json::from_str::<CategoryResponse>(response).expect("unable to deserialize");
     }
 
     #[test]
     fn deserialize_failure() {
         let response = include_str!("../../sample_json/bad-category.json");
-        json::from_str::<ApiResponse<CategoryPayload>>(response).expect("unable to deserialize");
+        json::from_str::<CategoryResponse>(response).expect("unable to deserialize");
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,3 @@
-use serde::Deserialize;
 use service::Result;
 
 mod author;
@@ -6,13 +5,11 @@ mod category;
 mod image;
 mod quote;
 
-pub use model::author::{Authors, AuthorPayload};
-pub use model::category::{Categories, CategoryPayload};
+pub use model::author::*;
+pub use model::category::*;
 pub use model::image::{Image, ImagePayload};
 pub use model::quote::{Quote, MultiQuotePayload};
 
-pub type AuthorResponse = ApiResponse<AuthorPayload>;
-pub type CategoryResponse = ApiResponse<CategoryPayload>;
 pub type ImageResponse = ApiResponse<ImagePayload>;
 pub type SingleQuoteResponse = ApiResponse<Quote>;
 pub type MultiQuoteResponse = ApiResponse<MultiQuotePayload>;
@@ -36,7 +33,7 @@ pub struct ApiError {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ApiResponse<T: Deserialize> {
+pub struct ApiResponse<T> {
     pub success: Option<ApiSuccess>,
     pub error: Option<ApiError>,
     pub reason: Option<String>,

--- a/src/model/quote.rs
+++ b/src/model/quote.rs
@@ -1,6 +1,4 @@
-use std::result;
 use model::{Content, SingleQuoteResponse, MultiQuoteResponse};
-use serde::{Deserialize, Deserializer};
 use service::{Error, Result};
 
 #[derive(Debug, Deserialize)]
@@ -20,34 +18,12 @@ impl Content<Quote> for SingleQuoteResponse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub struct Quote {
     pub quote: String,
     pub author: String,
     pub background: Option<String>,
     pub id: String,
-}
-
-
-impl Deserialize for Quote {
-    fn deserialize<D: Deserializer>(d: D) -> result::Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        struct Template {
-            pub quote: String,
-            pub author: String,
-            pub background: Option<String>,
-            pub id: String,
-        }
-
-        let template = Template::deserialize(d)?;
-
-        Ok(Quote {
-            quote: template.quote,
-            author: template.author,
-            background: template.background,
-            id: template.id,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/src/service/response.rs
+++ b/src/service/response.rs
@@ -1,15 +1,15 @@
 use std::io::Read;
 use hyper::client;
 use serde_json as json;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use service::Result;
 
 pub trait Response {
-    fn model<T: Deserialize>(&mut self) -> Result<T>;
+    fn model<T: DeserializeOwned>(&mut self) -> Result<T>;
 }
 
 impl Response for client::Response {
-    fn model<T: Deserialize>(&mut self) -> Result<T> {
+    fn model<T: DeserializeOwned>(&mut self) -> Result<T> {
         let mut buf = String::new();
         self.read_to_string(&mut buf)?;
         Ok(json::from_str(&buf)?)


### PR DESCRIPTION
This patch also fixes a longstanding bug in the way we deserialize author and category listings. The bug never mattered before because the API doesn't *really* support getting those (and anyway they're only available to premium members), but basically the API response for those
calls returns a string instead of a number as the "total" available.

...Anyway, instead of using a single `ApiResponse` wrapper, we have a standard response wrapper and then one response struct each for Author and for Category. Which is stupid as hell, but I don't really care to tell them how to run their business, I guess.

Hell, it's possible they've changed this API since the last time I checked; it's not as if I'm going to give them another months' membership fees to find out.

.......Anyway, I don't really even know how that was being handled before--I don't know if the tests that covered that just never worked before (the build is listed as passing?!) or if maybe the older version of serde just went ahead and parsed a string as an integer if you asked it to or what, but for *those* API endpoints, we now parse the "number" as an `Option(i32)` because I have no idea what to show our users if they send back `"lots"` instead of `1513297`.